### PR TITLE
removes unnecessary lines in signup page spec

### DIFF
--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -65,8 +65,6 @@ describe ApplicationController do
         :password => "rainbows"
       }
       post '/signup', params
-      session = {}
-      session[:user_id] = user.id
       get '/signup'
       expect(last_response.location).to include('/tweets')
     end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -57,8 +57,7 @@ describe ApplicationController do
       expect(last_response.location).to include('/signup')
     end
 
-    it 'does not let a logged in user view the signup page' do
-      user = User.create(:username => "skittles123", :email => "skittles@aol.com", :password => "rainbows")
+  it 'creates a new user, logs them in on valid submission, and does not let a logged in user view the signup page' do
       params = {
         :username => "skittles123",
         :email => "skittles@aol.com",


### PR DESCRIPTION
We were thinking that the tests were simulating the user being logged in, but this session hash actually has no affect on the session hash that is accessible within get 'signup', so it was throwing us off. These lines aren't doing anything, so it'll probably be clearer to leave them out.