### PR TITLE
Fix test so user exists first before logging in

### DIFF
--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -89,6 +89,7 @@ describe ApplicationController do
     end
 
     it 'does not let user view login page if already logged in' do
+      user = User.create(:username => "becky567", :email => "starz@aol.com", :password => "kittens")
       params = {
         :username => "becky567",
         :password => "kittens"

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -319,8 +319,6 @@ describe ApplicationController do
         fill_in(:username, :with => "becky567")
         fill_in(:password, :with => "kittens")
         click_button 'submit'
-        session = {}
-        session[:user_id] = user1.id
         visit "/tweets/#{tweet2.id}/edit"
         expect(page.current_path).to include('/tweets')
       end


### PR DESCRIPTION
@curiositypaths Tests can't log in a user if there are no users when the login request is sent.